### PR TITLE
Add hourly weather email script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-# aaa
+# Weather Mailer
+
+`weather_mailer.py` fetches the current weather from the OpenWeatherMap API and
+sends it to your email inbox every hour.
+
+## Requirements
+
+- Python 3
+- Packages: `requests` and `schedule`
+
+Install dependencies with:
+
+```bash
+pip install requests schedule
+```
+
+## Configuration
+
+Set the following environment variables before running the script:
+
+- `WEATHER_API_KEY` – API key from [OpenWeatherMap](https://openweathermap.org/)
+- `WEATHER_CITY` – city to check (default is `London`)
+- `SMTP_SERVER` – address of your SMTP server
+- `SMTP_PORT` – SMTP port (default `587`)
+- `SMTP_USER` – SMTP user name (also used as sender)
+- `SMTP_PASSWORD` – SMTP password
+- `RECIPIENT_EMAIL` – address to send updates to
+
+## Usage
+
+Run the script with Python:
+
+```bash
+python weather_mailer.py
+```
+
+It sends one update immediately and then continues running, sending a new email
+once every hour. Use a process manager or cron if you want the script to run in
+the background.

--- a/weather_mailer.py
+++ b/weather_mailer.py
@@ -1,0 +1,61 @@
+import os
+import time
+import requests
+from email.mime.text import MIMEText
+import smtplib
+import schedule
+
+API_KEY = os.environ.get('WEATHER_API_KEY')
+CITY = os.environ.get('WEATHER_CITY', 'London')
+SMTP_SERVER = os.environ.get('SMTP_SERVER')
+SMTP_PORT = int(os.environ.get('SMTP_PORT', '587'))
+SMTP_USER = os.environ.get('SMTP_USER')
+SMTP_PASSWORD = os.environ.get('SMTP_PASSWORD')
+RECIPIENT = os.environ.get('RECIPIENT_EMAIL')
+SENDER = SMTP_USER
+
+
+def get_weather() -> str:
+    if not API_KEY:
+        raise ValueError('WEATHER_API_KEY environment variable not set')
+    resp = requests.get(
+        'https://api.openweathermap.org/data/2.5/weather',
+        params={'q': CITY, 'appid': API_KEY, 'units': 'metric'},
+        timeout=10,
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    desc = data['weather'][0]['description']
+    temp = data['main']['temp']
+    return f'Weather in {CITY}: {desc}, {temp} °C'
+
+
+def send_email(text: str) -> None:
+    if not (SMTP_SERVER and SMTP_USER and SMTP_PASSWORD and RECIPIENT):
+        raise ValueError('SMTP configuration environment variables missing')
+    msg = MIMEText(text)
+    msg['Subject'] = f'Weather update for {CITY}'
+    msg['From'] = SENDER
+    msg['To'] = RECIPIENT
+
+    with smtplib.SMTP(SMTP_SERVER, SMTP_PORT) as server:
+        server.starttls()
+        server.login(SMTP_USER, SMTP_PASSWORD)
+        server.send_message(msg)
+
+
+def job() -> None:
+    text = get_weather()
+    send_email(text)
+
+
+def main() -> None:
+    job()  # run once at startup
+    schedule.every().hour.do(job)
+    while True:
+        schedule.run_pending()
+        time.sleep(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- provide README instructions for weather_mailer
- add `weather_mailer.py` script for hourly emailed forecast

## Testing
- `python3 -m py_compile weather_mailer.py`


------
https://chatgpt.com/codex/tasks/task_e_683ffe332f048329a39f428fb4e84b9b