### PR TITLE
Add py2app packaging instructions and script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
-# aaa
+# Textile Product Info Manager
+
+This repository contains a small GUI application for managing textile fabric information. It allows you to enter a product ID and view the associated details. You can also print the displayed information using your macOS default printer.
+
+## Requirements
+
+- Python 3 (tested with Python 3.8+)
+- Tkinter (comes with the standard Python installation on macOS)
+
+## Usage
+
+1. Open a terminal and navigate to this repository directory.
+2. Run the application:
+
+```bash
+python3 main.py
+```
+
+3. Enter a product ID (e.g., `TX001` or `TX002`) and click **Search** to view the product details.
+4. Click **Print** to send the displayed information to your default printer (uses the `lpr` command on macOS).
+
+You can extend the `PRODUCT_DATA` dictionary in `main.py` to include additional fabric products.
+
+## Packaging as a macOS App
+
+To create a standalone `.app` bundle using **py2app**:
+
+1. Install py2app:
+
+   ```bash
+   pip install py2app
+   ```
+
+2. Run the build script:
+
+   ```bash
+   python3 setup.py py2app
+   ```
+
+3. After the build completes, the application bundle will be located in the `dist` directory. You can move the generated `.app` to your Applications folder.
+
+The provided `setup.py` is configured with basic options and uses the GUI script `main.py` as the entry point.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,89 @@
+import tkinter as tk
+from tkinter import messagebox
+import subprocess
+import tempfile
+
+# Sample product data for textile fabrics
+PRODUCT_DATA = {
+    "TX001": {
+        "name": "Cotton Twill",
+        "composition": "100% cotton",
+        "width": "150cm",
+        "weight": "180gsm",
+        "color": "Blue"
+    },
+    "TX002": {
+        "name": "Polyester Satin",
+        "composition": "100% polyester",
+        "width": "145cm",
+        "weight": "120gsm",
+        "color": "Red"
+    },
+    # Add more product entries as needed
+}
+
+def get_product_info(pid):
+    """Return formatted product info string for the given product ID."""
+    info = PRODUCT_DATA.get(pid.upper())
+    if not info:
+        return None
+    lines = [f"Product ID: {pid.upper()}"]
+    for key, value in info.items():
+        lines.append(f"{key.capitalize()}: {value}")
+    return "\n".join(lines)
+
+def print_info(text):
+    """Send the provided text to the default printer on macOS using lpr."""
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".txt") as tmp:
+        tmp.write(text)
+        tmp_filename = tmp.name
+    try:
+        subprocess.run(["lpr", tmp_filename], check=True)
+    except Exception as e:
+        messagebox.showerror("Print Error", f"Failed to print: {e}")
+
+class ProductApp(tk.Tk):
+    def __init__(self):
+        super().__init__()
+        self.title("Textile Product Info")
+        self.geometry("400x250")
+
+        self.pid_label = tk.Label(self, text="Enter Product ID:")
+        self.pid_label.pack(pady=5)
+        self.pid_entry = tk.Entry(self)
+        self.pid_entry.pack(fill="x", padx=20)
+
+        self.info_text = tk.Text(self, height=8)
+        self.info_text.pack(fill="both", expand=True, padx=20, pady=5)
+
+        self.button_frame = tk.Frame(self)
+        self.button_frame.pack(pady=5)
+
+        self.search_button = tk.Button(self.button_frame, text="Search", command=self.search)
+        self.search_button.pack(side="left", padx=5)
+
+        self.print_button = tk.Button(self.button_frame, text="Print", command=self.print_current)
+        self.print_button.pack(side="left", padx=5)
+
+    def search(self):
+        pid = self.pid_entry.get().strip()
+        if not pid:
+            messagebox.showwarning("Input Error", "Please enter a product ID")
+            return
+        info = get_product_info(pid)
+        self.info_text.delete("1.0", tk.END)
+        if info:
+            self.info_text.insert(tk.END, info)
+        else:
+            self.info_text.insert(tk.END, f"No information found for ID: {pid}")
+
+    def print_current(self):
+        text = self.info_text.get("1.0", tk.END).strip()
+        if not text:
+            messagebox.showwarning("No Data", "No product information to print")
+            return
+        print_info(text)
+
+if __name__ == "__main__":
+    app = ProductApp()
+    app.mainloop()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup
+
+APP = ['main.py']
+OPTIONS = {
+    'argv_emulation': True,
+}
+
+setup(
+    app=APP,
+    options={'py2app': OPTIONS},
+    setup_requires=['py2app'],
+)


### PR DESCRIPTION
## Summary
- document how to package the GUI as a macOS app
- add minimal `setup.py` for building with py2app

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_684000e2114c83299192509762e39ab6